### PR TITLE
Feat/fix a couple of errors in resolutions visualization

### DIFF
--- a/components/ResolutionInfo.tsx
+++ b/components/ResolutionInfo.tsx
@@ -39,8 +39,13 @@ export default function ResolutionInfo({
   const { address, isConnected } = useAccount();
   const { user } = useUser();
 
-  const votingUser =
+  const canVote =
     address || user?.ethereum_address
+      ? resolution.voters.find((voter) => isSameAddress(voter.address, address || (user?.ethereum_address as string)))
+      : null;
+
+  const votingUser =
+    canVote && (address || user?.ethereum_address)
       ? resolution.votingStatus.votersHaveVoted.find((voter) =>
           isSameAddress(voter.address, address || (user?.ethereum_address as string)),
         )
@@ -100,9 +105,12 @@ export default function ResolutionInfo({
           "&::-webkit-scrollbar": { display: "none" },
         }}
       >
-        {!votingUser && RESOLUTION_STATES.ENDED === resolution.state && (isConnected || user?.isLoggedIn) && (
-          <Chip size={chipSize} sx={{ mr: hideState ? 0 : 2 }} label="Abstained, counts as No" variant="outlined" />
-        )}
+        {canVote &&
+          !votingUser &&
+          RESOLUTION_STATES.ENDED === resolution.state &&
+          (isConnected || user?.isLoggedIn) && (
+            <Chip size={chipSize} sx={{ mr: hideState ? 0 : 2 }} label="Abstained, counts as No" variant="outlined" />
+          )}
         {votingUser && (isConnected || user?.isLoggedIn) && (
           <>
             <Typography variant="body2">Your Vote: </Typography>

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -30,7 +30,7 @@ const getVotingInfo = (percentage: number | null) => {
   if (percentage === null) {
     return {
       severity: "info",
-      message: "You haven't voted on any resolution this year",
+      message: "You are not connected with your wallet or you haven't voted on any resolution this year",
     };
   }
 
@@ -121,11 +121,10 @@ export default function Header({ votingPercentageInTheYear }: { votingPercentage
           </>
         )}
       </Paper>
-      {typeof votingPercentageInTheYear === "number" && (
-        <Alert severity={votingSeverity as AlertColor} sx={{ mt: 2, width: "100%" }}>
-          {votingInfoMessage}
-        </Alert>
-      )}
+
+      <Alert severity={votingSeverity as AlertColor} sx={{ mt: 2, width: "100%" }}>
+        {votingInfoMessage}
+      </Alert>
     </>
   );
 }

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -30,7 +30,7 @@ const getVotingInfo = (percentage: number | null) => {
   if (percentage === null) {
     return {
       severity: "info",
-      message: "You are not connected with your wallet or you haven't voted on any resolution this year",
+      message: "You haven't voted on any resolution this year",
     };
   }
 

--- a/components/resolutions/ExecutionPayload.tsx
+++ b/components/resolutions/ExecutionPayload.tsx
@@ -46,7 +46,8 @@ export default function ExecutionPayload({
             <Box key={userData.address}>
               <Typography variant="body2">
                 <b>
-                  {userData.tokens} {TOKEN_SYMBOL}
+                  {!Number.isNaN(Number(userData.tokens)) ? Number(userData.tokens).toFixed(2) : userData.tokens}{" "}
+                  {TOKEN_SYMBOL}
                 </b>{" "}
                 to
               </Typography>

--- a/lib/resolutions/common.ts
+++ b/lib/resolutions/common.ts
@@ -266,5 +266,5 @@ export const getVotingPercentage = (allResolutions: ResolutionEntityEnhanced[], 
 
   const votedResolutions = yourVotedResolutions.length;
 
-  return totalVotable === 0 ? 0 : (100 * votedResolutions) / totalVotable;
+  return totalVotable === 0 ? null : (100 * votedResolutions) / totalVotable;
 };


### PR DESCRIPTION
# Description

Fix a couple of issues with resolution data visualizations:

1. Vote showed as abstained when not able to vote (in the resolutions list page)
![image](https://github.com/NeokingdomDAO/dapp/assets/2692166/5443c951-3c77-4f50-a868-9f2b6f9e6280)
2. Do not show 0% vote when you couldn't vote on any resolutions
![image](https://github.com/NeokingdomDAO/dapp/assets/2692166/b8084da8-de6f-4a9e-8b78-ef1513e124ea)
3. Show just two decimal value in payload execution view
